### PR TITLE
send the right x-api-header

### DIFF
--- a/slideshowApp.js
+++ b/slideshowApp.js
@@ -170,6 +170,7 @@ var Slideshow;
                   data: event
                 };
                 xhr.open('POST', this.remoteLocation, true);
+                xhr.setRequestHeader("x-api-proxy", this.session)
                 xhr.setRequestHeader("Content-Type", "application/json");
                 xhr.send(JSON.stringify(payload));
             }


### PR DESCRIPTION
Since we're using `qbank` logging directly, make sure to set the `x-api-proxy` header so that the right `agentId` is logged.